### PR TITLE
feat: remove CHANGELOG reference from README #204013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.3 - 2026-05-1
+### Added
+- No new functionality added.
+
+### Changed
+- Removed the CHANGELOG reference from the README.
+
+### Removed
+- No functionality removed.
+
 ## 1.2.2 - 2026-05-06
 ### Added
 - No new functionality added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.3 - 2026-05-1
+## 1.2.3 - 2026-05-11
 ### Added
 - No new functionality added.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Overview
 The `Audacia.Primitives` library provides some basic types that are often reimplemented in multiple projects. It has (and must continue to have) no dependencies beyond the core .NET libraries.
 
-It is published as a NuGet package to Audacia's internal NuGet feed.
-
-# Change History
-The `Audacia.Primitives` repository change history can be found in this [changelog](./CHANGELOG.md)
+It is published as a NuGet package.
 
 # Contributing
 We welcome contributions! Please feel free to check our [Contribution Guidlines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.

--- a/src/Audacia.Primitives/Audacia.Primitives.csproj
+++ b/src/Audacia.Primitives/Audacia.Primitives.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <WarningLevel>9999</WarningLevel>
-	  <Version>1.2.2</Version>
+	  <Version>1.2.3</Version>
 	  <Authors>Audacia</Authors>
 	  <Description>.NET library containing useful 'primitive' types.</Description>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Audacia.Primitives.Tests/Audacia.Primitives.Tests.csproj
+++ b/tests/Audacia.Primitives.Tests/Audacia.Primitives.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Authors>Audacia</Authors>
-        <Version>1.2.2</Version>
+        <Version>1.2.3</Version>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG

### Code ready for review
- ❎ No code changes (e.g. just a documentation change)

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ❎ No new/upgraded dependencies

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR